### PR TITLE
Add working TOTP 2FA support

### DIFF
--- a/html/process/settings/twoFactor_disable.php
+++ b/html/process/settings/twoFactor_disable.php
@@ -1,0 +1,42 @@
+<?php 
+
+require_once(__DIR__.'/../../includes/session.php');
+
+// if no session, just die silently
+if ($session == false) {
+    exit();
+}
+
+// we're returning JSON
+header('Content-Type: application/json');
+$data = array();
+
+// verify CSRF
+$easyCSRF = new \EasyCSRF\EasyCSRF($sessionObj);
+try {
+    $easyCSRF->check($sessionObj->sessionData['csrfName'], $_POST['token'], 60*15, true);
+} catch(\EasyCSRF\Exceptions\InvalidCsrfTokenException $e) {
+    // csrf error! exit early
+    $data['code'] = 'ERR_CSRF_FAILURE';
+    echo json_encode($data);
+    exit();
+}
+
+$user = $sessionObj->user;
+
+// check the user's password
+if (!$user->confirmPassword($_POST['password'])) {
+    // nu-uh! exit early
+    $data['code'] = 'ERR_INVALID_CREDS';
+    echo json_encode($data);
+    exit();
+}
+
+// if we get here, password is correct, we can go ahead and disable 2FA
+if ($user->disableTwoFactor()) {
+    $data['code'] = 'SUCCESS';
+} else {
+    $data['code'] = 'ERR_BACKEND_FAILURE';
+}
+
+echo json_encode($data);

--- a/html/process/settings/twoFactor_enable.php
+++ b/html/process/settings/twoFactor_enable.php
@@ -1,0 +1,55 @@
+<?php 
+
+require_once(__DIR__.'/../../includes/session.php');
+
+// if no session, just die silently
+if ($session == false) {
+    exit();
+}
+
+// we're returning JSON
+header('Content-Type: application/json');
+$data = array();
+
+// verify CSRF
+$easyCSRF = new \EasyCSRF\EasyCSRF($sessionObj);
+try {
+    $easyCSRF->check($sessionObj->sessionData['csrfName'], $_POST['token'], 60*15, true);
+} catch(\EasyCSRF\Exceptions\InvalidCsrfTokenException $e) {
+    // csrf error! exit early
+    $data['code'] = 'ERR_CSRF_FAILURE';
+    echo json_encode($data);
+    exit();
+}
+
+$user = $sessionObj->user;
+$secretKey = $sessionObj->sessionData['totpsecret'];
+if ($secretKey == null || $secretKey == '') {
+    // oh no! we don't have a secret key, so we can't really do anything
+    $data['code'] = 'ERR_NO_SECRET';
+    echo json_encode($data);
+    exit();
+}
+
+// check the TOTP code, if it's valid enable 2FA
+$result = $user->enableTwoFactor($secretKey, trim($_POST['totpcode']));
+if ($result == false) {
+    // invalid TOTP code or an error occurred, exit early
+    $data['code'] = 'ERR_INVALID_2FA';
+    echo json_encode($data);
+    exit();
+} else if ($result == 0) {
+    // result == 0 is a special case - the database update failed
+    $data['code'] = 'ERR_BACKEND_FAILURE';
+    echo json_encode($data);
+    exit();
+}
+
+// if we get here, 2FA is now enabled!
+// get rid of the secret from the session
+$sessionObj->sessionData['totpsecret'] = null;
+$sessionObj->updateSession();
+
+// and return success
+$data['code'] = 'SUCCESS';
+echo json_encode($data);

--- a/html/process/user/login.php
+++ b/html/process/user/login.php
@@ -49,21 +49,19 @@ if ($session !== false) {
             echo $json;
             exit();
         } 
-        if ($user->secretKey != null && $user->secretKey != '' && (!isset($twoFactor) || $twoFactor == '')) {
+        if ($user->hasTwoFactor() && (!isset($twoFactor) || $twoFactor == '')) {
             // 2FA is there, but not in the form. 
             $data['code'] = 'ERR_2FA_NEEDED';
         } else {
-            if (isset($twoFactor) && $user->secretKey != null && $user->secretKey != '') {
+            if ($user->hasTwoFactor() && isset($twoFactor)) {
                 // Check the 2FA code. 
-                $ga = new \Steelblade\GoogleAuthenticator\GoogleAuthenticator();      
-                if ($ga->checkCode($user->secretKey, $twoFactor) == false) {
+                if (!$user->verifyTwoFactor($twoFactor)) {
                     $data['code'] = 'ERR_INVALID_2FA';
-                    $json = json_encode($data);
-                    echo $json;
-                    exit();
-                    // Exit early to make things cleaner. 
+                    echo json_encode($data);
+                    exit(); // Exit early to make things cleaner. 
                 }
             }
+
             // If we get here, there's no 2FA, or it passed. 
             // Note: 0 is distinct from false for the login command and means
             // something different. 

--- a/html/settings/twoFactor.php
+++ b/html/settings/twoFactor.php
@@ -1,18 +1,11 @@
 <?php 
-
 require_once(__DIR__.'/../includes/header.php');
-$user = $sessionObj->user;
 
-if ($user->hasTwoFactor()) {
+$user = $sessionObj->user;
+$easyCSRF = new EasyCSRF\EasyCSRF($sessionObj);
+$token = $easyCSRF->generate($sessionObj->sessionData['csrfName']);
 ?>
-<script>
-    totpMode = 'disable';
-</script>
-<?php } else { ?>
-    <script>
-    totpMode = 'enable';
-</script>
-<?php } ?>
+
 <div class="container">
     <div class="container-fluid col mx-auto">
         <div class="row">
@@ -21,19 +14,72 @@ if ($user->hasTwoFactor()) {
                     <div class="card-header">
                         Two Factor Authentication
                     </div>
+
                     <div class="card-body">
-                        <?php if ($user->hasTwoFactor()) {
-                            // Enabled. Have the user enter their password to disable it. 
-                            ?>
-                            
-                        <?php } else { 
-                            // Not enabled
-                        } ?>
-                        <p>Two Factor Authentication (2FA) can add an extra layer of security to your account, by requiring a six digit code to be entered
+                        <?php if ($user->hasTwoFactor()) { 
+                            // User has two-factor auth enabled, so prompt for password to disable it
+                        ?>
+                            <p>To disable Two Factor Authentication, enter your password below.</p>
+
+                            <form id="UserSettingsDisableTwoFactorForm" action="https://<?php echo $_ENV['SITE_URL']; ?>/process/settings/twoFactor_disable.php" method="post">
+                                <input type="hidden" id="token" name="token" value="<?php echo $token; ?>">
+                                <div class="form-group row">
+                                    <div class="col">
+                                        <label class="control-label" for="password">Password:</label>
+                                        <input id="password" maxlength="50" class="form-control" name="password" type="password">
+                                    </div>
+                                </div>
+
+                                <div class="form-group row">
+                                    <div class="col">
+                                        <button name="submit" type="submit" class="btn btn-primary" id="submit" form="UserSettingsDisableTwoFactorForm">Disable two-factor authentication</button>
+                                    </div>
+                                </div>
+                            </form>
+
+                        <?php } else {
+                            // Not enabled 
+                            $secretKey = $sessionObj->sessionData['totpsecret'];
+                            if ($secretKey == null || $secretKey == '') {
+                                $ga = new \Steelblade\GoogleAuthenticator\GoogleAuthenticator();
+                                $secretKey = $ga->generateSecret();
+                                $sessionObj->sessionData['totpsecret'] = $secretKey;
+                                $sessionObj->updateSession();
+                            }
+
+                            $qrCodeUrl = \Steelblade\GoogleAuthenticator\GoogleQrUrl::generate($user->email, $secretKey, $_ENV['SITE_URL']);
+                        ?>
+                            <p>Two Factor Authentication (2FA) can add an extra layer of security to your account, by requiring a six digit code to be entered
                             from a separate authenticator app in addition to your password. The downside is if you lose access to the app (usually on your phone), 
                             you also lose access to your account, as support won't be able to recover it for you.</p>
-                        <p>Before continuing, make sure you have a TOTP capable app handy. Waterfall recommends Google Authenticator. 
-                        <div id="DisplayDiv" name="DisplayDiv">
+                            <p>Before continuing, make sure you have a TOTP capable app handy. Waterfall recommends Google Authenticator.</p>
+                            <p>To continue, scan the below QR code with your authenticator app. Your authenticator app will give you a 6 digit code, which you need to enter below now, and every time you log into Waterfall.</p>
+
+                            <form id="UserSettingsEnableTwoFactorForm" action="https://<?php echo $_ENV['SITE_URL']; ?>/process/settings/twoFactor_enable.php" method="post">
+                                <input type="hidden" id="token" name="token" value="<?php echo $token; ?>">
+                                <div class="form-group row">
+                                    <div class="col">
+                                        <img src="<?php echo $qrCodeUrl; ?>">
+                                        <p>If you can't scan this code with your authenticator app, you can manually enter the following secret key into the app: <code><?php echo $secretKey; ?></code></p>
+                                    </div>
+                                </div>
+
+                                <div class="form-group row">
+                                    <div class="col">
+                                        <label class="control-label" for="totpcode">Authentication code:</label>
+                                        <input id="totpcode" maxlength="6" class="form-control" name="totpcode" type="text" pattern="[0-9]+">
+                                    </div>
+                                </div>
+
+                                <div class="form-group row">
+                                    <div class="col">
+                                        <button name="submit" type="submit" class="btn btn-primary" id="submit" form="UserSettingsEnableTwoFactorForm">Enable two-factor authentication</button>
+                                    </div>
+                                </div>
+                            </form>
+                        <?php } ?>
+
+                        <div id="DisplayDiv" name="DisplayDiv"></div>
                     </div>
                 </div>
             </div>
@@ -41,7 +87,97 @@ if ($user->hasTwoFactor()) {
     </div>
 </div>
 
-<script src="https://<?php echo $_ENV['SITE_URL']; ?>/js/two-factor.js"></script>
+<?php if ($user->hasTwoFactor()) { ?>
+<script type="text/javascript">
+$(document).ready(function() {
+    $('#UserSettingsDisableTwoFactorForm').submit(function(event) {
+        event.preventDefault();
 
+        var formData = new FormData();
+        formData.append('token', '<?php echo $token; ?>');
+        formData.append('password', $("#password").val());
+
+        fetch($(event.target).attr("action"), {
+            method: 'POST',
+            mode: 'cors',
+            credentials: 'include',
+            redirect: 'follow',
+            body: formData,
+        }).then(function(response) {
+            if (response.status !== 200) {
+                console.log('Error logged, status code: ' + response.status);
+                $("#DisplayDiv").html('<?php UIUtils::errorBox("There was an error trying to disable two-factor authentication. Please contact support."); ?>');
+                return false;
+            }
+
+            response.json().then(function(data) {
+                if (data.code == "SUCCESS") {
+                    $("#DisplayDiv").html('<?php UIUtils::successBox("Successfully disabled two-factor authentication. Redirecting you to User Settings..."); ?>');
+                    window.location.href = "https://<?php echo $_ENV['SITE_URL']; ?>/settings/user";
+                    return false;
+
+                } else if (data.code == "ERR_CSRF_FAILURE") {
+                    $("#DisplayDiv").html('<?php UIUtils::errorBox("CSRF failure. Please refresh the page and try again."); ?>');
+                } else if (data.code == "ERR_INVALID_CREDS") {
+                    $("#DisplayDiv").html('<?php UIUtils::errorBox("Your password was incorrect. Please try again."); ?>');
+                } else {
+                    $("#DisplayDiv").html('<?php UIUtils::errorBox("There was an error trying to disable two-factor authentication. Please contact support."); ?>');
+                }
+            })
+        }).catch(function(err) {
+            $("#DisplayDiv").html('<?php UIUtils::errorBox("There was an error trying to disable two-factor authentication. It\'s most likely temporary, so try again - but if it persists, please contact support so we can look into it."); ?>');
+        });
+
+        return false; // cancel original event to prevent form submitting
+    });
+});
+</script>
+<?php } else { ?>
+<script type="text/javascript">
+$(document).ready(function() {
+    $('#UserSettingsEnableTwoFactorForm').submit(function(event) {
+        event.preventDefault();
+
+        var formData = new FormData();
+        formData.append('token', '<?php echo $token; ?>');
+        formData.append('totpcode', $("#totpcode").val());
+
+        fetch($(event.target).attr("action"), {
+            method: 'POST',
+            mode: 'cors',
+            credentials: 'include',
+            redirect: 'follow',
+            body: formData,
+        }).then(function(response) {
+            if (response.status !== 200) {
+                console.log('Error logged, status code: ' + response.status);
+                $("#DisplayDiv").html('<?php UIUtils::errorBox("There was an error trying to enable two-factor authentication. Please contact support."); ?>');
+                return false;
+            }
+
+            response.json().then(function(data) {
+                if (data.code == "SUCCESS") {
+                    $("#DisplayDiv").html('<?php UIUtils::successBox("Successfully enabled two-factor authentication! Redirecting you to User Settings..."); ?>');
+                    window.location.href = "https://<?php echo $_ENV['SITE_URL']; ?>/settings/user";
+                    return false;
+
+                } else if (data.code == "ERR_CSRF_FAILURE") {
+                    $("#DisplayDiv").html('<?php UIUtils::errorBox("CSRF failure. Please refresh the page and try again."); ?>');
+                } else if (data.code == "ERR_INVALID_2FA") {
+                    $("#DisplayDiv").html('<?php UIUtils::errorBox("The provided authentication code was incorrect. Please try again."); ?>');
+                } else {
+                    $("#DisplayDiv").html('<?php UIUtils::errorBox("There was an error trying to enable two-factor authentication. Please contact support."); ?>');
+                }
+            })
+        }).catch(function(err) {
+            $("#DisplayDiv").html('<?php UIUtils::errorBox("There was an error trying to enable two-factor authentication. It\'s most likely temporary, so try again - but if it persists, please contact support so we can look into it."); ?>');
+        });
+
+        return false; // cancel original event to prevent form submitting
+    });
+});
+</script>
+
+<?php } ?>
 
 <?php require_once(__DIR__.'/../includes/footer.php'); ?>

--- a/html/settings/user.php
+++ b/html/settings/user.php
@@ -415,18 +415,20 @@ $token = $easyCSRF->generate($sessionObj->sessionData['csrfName']);
                                         }
                                     }
                                 } ?>
-                                <hr>
-                            <!--<p>Two Factor Authentication (2FA) can add an extra layer of security to your account, by requiring a six digit code to be entered
-                            from a separate authenticator app in addition to your password. The downside is if you lose access to the app (usually on your phone), 
-                            you also lose access to your account, as support won't be able to recover it for you.</p>
-                            <p>2FA is good practice for all users, but is especially recommended if you use the Commission Marketplace.</p>
+                            </li>
+                            <li class="list-group-item">
+                                <h5 class="card-title"><i class="fas fa-key title-icon"></i>Two Factor Authentication</h5>
+                            <p>Two Factor Authentication (2FA) can add an extra layer of security to your account, by requiring a six digit code to be entered from a separate authenticator app in addition to your password. The downside is if you lose access to the app (usually on your phone),  you also lose access to your account, as support won't be able to recover it for you.</p>
+                            <!--<p>2FA is good practice for all users, but is especially recommended if you use the Commission Marketplace.</p>-->
                             <p>2FA Status for this account: 
                             <?php if ($user->hasTwoFactor()) {
-                                ?> <a href="https://<?php echo $_ENV['SITE_URL']; ?>/settings/totp" role="button" name="twoFactorButton" class="btn btn-success">ENABLED</a> <?php
+                                ?> <a href="https://<?php echo $_ENV['SITE_URL']; ?>/settings/totp" role="button" name="twoFactorButton" class="btn btn-success">Enabled</a> <?php
                             } else {
-                                ?> <a href="https://<?php echo $_ENV['SITE_URL']; ?>/settings/totp" role="button" name="twoFactorButton" class="btn btn-outline-danger">DISABLED</a>  <?php
+                                ?> <a href="https://<?php echo $_ENV['SITE_URL']; ?>/settings/totp" role="button" name="twoFactorButton" class="btn btn-outline-danger">Disabled</a>  <?php
                             }?></p>
-                            <p>Use the button above to toggle it on or off.</p> Another last minute bug. Be back soon.-->
+                            <p>Use the button above to toggle it on or off.</p>
+                            </li>
+                            <li class="list-group-item">
                             <div class="row"><div class="col"><button type="button" role="button" class="float-right btn btn-outline-danger" data-toggle="collapse" data-target="#deleteCollapse" aria-expanded="false" aria-controls="deleteCollapse">Delete Account</button></div></div>
                             <div class="collapse" id="deleteCollapse">
                                 <p>If you no longer wish to use the site for any reason, please enter your password below to confirm.</p>


### PR DESCRIPTION
The UI for enabling 2FA isn't very pretty, but it works. This also uncomments the section of the User Settings page relating to 2FA (keeping the paragraph about the Commission Marketplace commented), adds a card title to that section, and fixes a tiny stylistic issue regarding the "Delete Account" section (it wasn't it's own `li.list-group-item`, and so the margins were off).

Closes #6. 