### PR TITLE
Make Sentry optional when ENVIRONMENT=dev

### DIFF
--- a/src/loader.php
+++ b/src/loader.php
@@ -48,31 +48,25 @@ $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
 $dotenv->load();
 try {
   $dotenv->required('ENVIRONMENT')->allowedValues(['dev', 'staging', 'prod']);
-  $dotenv->required('SENTRY_DSN')->notEmpty();
   $dotenv->required('MAINTENANCE')->allowedValues(['on', 'vip', 'off']);
 
+  // If our environment is 'dev', make Sentry optional
+  if ($_ENV['ENVIRONMENT'] != 'dev') {
+    $dotenv->required('SENTRY_DSN')->notEmpty();
+  }
 } catch (Exception $e) {
   echo $e;
   exit();
 }
 
-
-\Sentry\init(['dsn' => $_ENV['SENTRY_DSN'] ]);
-
-
-
+// Only load Sentry if we have a SENTRY_DSN. The SENTRY_DSN
+// environment variable is required in all environments except
+// 'dev' (which is enforced above when loading Dotenv)
+if ($_ENV['SENTRY_DSN'] != null && $_ENV['SENTRY_DSN'] != '') {
+  \Sentry\init([ 'dsn' => $_ENV['SENTRY_DSN'] ]);
+}
 
 require_once(__DIR__."/classes/Emoji.class.php");
 
 $i18n = new i18n(__DIR__.'/../lang/lang_{LANGUAGE}.ini', __DIR__.'/../langcache/', 'en');
 $i18n->init();
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Pretty self-explanatory. This change makes it just that little bit easier to set up a development instance.