### PR TITLE
Update Pillow version for Raven

### DIFF
--- a/raven/requirements.txt
+++ b/raven/requirements.txt
@@ -17,7 +17,7 @@ lazy-object-proxy==1.4.3
 lxml==4.6.2
 MarkupSafe==1.1.1
 mccabe==0.6.1
-Pillow==8.0.0
+Pillow==8.1.2
 psutil==5.7.2
 psycopg2-binary==2.8.6
 pylint==2.6.0


### PR DESCRIPTION
Updates Raven's Pillow dependency. Already done on live. Closes vulnerability to:

CVE-2021-27923 (memory consumption DoS related to ICO containers)
CVE-2020-35654 (TiffDecode heap-based buffer overflow with crafted YCbCr files and RGBA mode)
CVE-2021-27921 (memory consumption DoS related to BLP containers)
CVE-2021-27922 (memory consumption DoS related to ICNS containers)
CVE-2020-35653 (PcxDecode buffer over-read when decoding crafted PCD files with bad stride values)
CVE-2020-35655 (SGIRleDecode buffer over-read)
