### PR TITLE
Open Graph tag support

### DIFF
--- a/blogs/includes/header.php
+++ b/blogs/includes/header.php
@@ -102,6 +102,7 @@ if (isset($blogPageType) && $failed === false) { ?>
             }
         ?>">
         <?php if (!empty($postMetadataContent = $post->metadataRender())) { ?>
+          <?php if (strlen($postMetadataContent) > 100) { $postMetadataContent = substr($postMetadataContent, 0, 100) . '...'; } ?>
           <meta property="og:description" content="<?php echo htmlspecialchars($postMetadataContent) ?>">
         <?php } ?>
 

--- a/blogs/includes/header.php
+++ b/blogs/includes/header.php
@@ -81,10 +81,46 @@ if (!$failed) {
 
 ?>
 <!doctype html>
+<html prefix="og: https://ogp.me/ns#">
 <head>
 <title><?php echo $pageTitle; ?></title>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+<?php // Render the OpenGraph tags!
+if (isset($blogPageType) && $failed === false) { ?>
+    <?php if ($blogPageType === 'post' && isset($post)) { ?>
+        <!-- Open Graph - blog post -->
+        <meta property="og:type" content="website">
+        <meta property="og:url" content="<?php echo $thisBlog->getBlogURL() . '/post/' . $post->ID ?>">
+        <meta property="og:title" content="<?php
+            if (is_null($post->postTitle) || empty($post->postTitle)) {
+                $postMetadataType = ucwords($post->postType);
+                echo htmlspecialchars("{$postMetadataType} post by {$thisBlog->blogTitle}");
+            } else {
+                echo htmlspecialchars("{$thisBlog->blogTitle} - {$post->postTitle}");
+            }
+        ?>">
+        <?php if (!empty($postMetadataContent = $post->metadataRender())) { ?>
+          <meta property="og:description" content="<?php echo htmlspecialchars($postMetadataContent) ?>">
+        <?php } ?>
+
+    <?php } elseif ($blogPageType === 'page' && isset($thisPage)) { ?>
+        <!-- Open Graph - blog page -->
+        <meta property="og:type" content="website">
+        <meta property="og:url" content="<?php echo $thisBlog->getBlogURL() . '/' . $thisPage->url ?>">
+        <meta property="og:title" content="<?php echo htmlspecialchars("{$thisBlog->blogTitle} - {$thisPage->pageTitle}") ?>">
+
+    <?php } elseif ($blogPageType === 'blog') { ?>
+        <!-- Open Graph - blog index -->
+        <meta property="og:type" content="website">
+        <meta property="og:url" content="<?php echo $thisBlog->getBlogURL() ?>">
+        <meta property="og:title" content="<?php echo htmlspecialchars($thisBlog->blogTitle) ?>">
+        <meta property="og:description" content="<?php echo htmlspecialchars($thisBlog->blogDescription) ?>">
+    <?php } ?>
+
+    <meta property="og:site_name" content="Waterfall">
+<?php } ?>
 
 <script src="https://code.jquery.com/jquery-3.5.1.min.js" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/luxon/1.25.0/luxon.min.js" integrity="sha512-OyrI249ZRX2hY/1CAD+edQR90flhuXqYqjNYFJAiflsKsMxpUYg5kbDDAVA8Vp0HMlPG/aAl1tFASi1h4eRoQw==" crossorigin="anonymous"></script><link rel="stylesheet" href="https://cdn.jsdelivr.net/chartist.js/latest/chartist.min.css">

--- a/blogs/index.php
+++ b/blogs/index.php
@@ -1,5 +1,7 @@
 <?php 
 
+$blogPageType = 'blog';
+
 require_once(__DIR__.'/includes/header.php');
 
 $isMobile = WFUtils::detectMobile();

--- a/blogs/page.php
+++ b/blogs/page.php
@@ -1,5 +1,6 @@
 <?php 
 require_once(__DIR__.'/../src/loader.php');
+$blogPageType = 'page';
 $url = $_SERVER['HTTP_HOST'];
 $tmp = explode('.', $url);
 $subdomain = WFText::makeTextSafe(current($tmp));

--- a/blogs/post.php
+++ b/blogs/post.php
@@ -1,13 +1,13 @@
 <?php 
 require_once(__DIR__.'/../src/loader.php');
 
+$blogPageType = 'post';
 if (!empty($_GET['post'])) {
 	$post = new Post(intval($_GET['post']));
 	$failed = false;
 } else {
 	$failed = true;
-  }
-
+}
 
 // Do meta stuff
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "mastersteelblade/google-authenticator": "^1.0",
         "mapkyca/php-ogp": "^1.0",
         "gilbitron/easycsrf": "^1.4",
-        "philipp15b/php-i18n": "^4.0"
+        "philipp15b/php-i18n": "^4.0",
+        "tgalopin/html-sanitizer": "^1.4"
     },
     "autoload": {
         "classmap": [

--- a/src/classes/Post.class.php
+++ b/src/classes/Post.class.php
@@ -519,6 +519,22 @@ class Post {
         <?php
     }
 
+    public function metadataRender() {
+        /**
+         * Render the last segment of a post that has content, stripping
+         * all markup from it, suitable for embedding in Open Graph tags.
+         */
+
+        $segments = $this->calculateSegments();
+        foreach (array_reverse($segments) as $segment) {
+            if ($this->textContentCheck($segment)) {
+                return WFText::makeTextStripped($segment->content);
+            }
+        }
+
+        return '';
+    }
+
     public function checkDNRStatus() {
         /**
          * Checks whether a post can be interacted with in a given way by iterating through tags. 

--- a/src/classes/WFText.class.php
+++ b/src/classes/WFText.class.php
@@ -61,6 +61,19 @@ class WFText {
         return $result;
     }
       
+    public static function makeTextStripped($content, $segmentID = 0) {
+        // Render as for edit
+        $content = self::makeTextRenderableForEdit($content, $segmentID);
+
+        // Strip out all HTML.
+        //
+        // HtmlSanitizer at it's default settings (with no extensions) will
+        // strip *everything*, which is what we want.
+        $sanitizer = \HtmlSanitizer\Sanitizer::create(['extensions' => []]);
+        $content = $sanitizer->sanitize($content);
+
+        return $content;
+    }
 
 
     public static function mentionReplace($content) {


### PR DESCRIPTION
Open Graph tags are rendered on the blog index, blog pages, and blog posts:

* The blog index renders tags for the blog title and description;
* Blog pages have a single tag for the page title (plus blog title), no embedding of page content is done, yet(?);
* Blog posts have:
    * Post title, if present (replaced with `{postType} post by {blogTitle}` if no post title is present)
    * Description tag set to the stripped content of the last non-empty segment (possibly should put a character limit on this?)

This will implement everything needed for Discord embeds, etc., closing #2. 

Currently a WIP, submitting now for review before I finish everything up in case there's any major changes that are needed. I still need to implement proper handling of non-text blog posts.