### PR TITLE
Blocking fixes: viewing blogs, and featured posts

### DIFF
--- a/blogs/includes/header.php
+++ b/blogs/includes/header.php
@@ -25,7 +25,7 @@ if ($thisBlog->failed) {
 }
 
 
-
+// Check if the owner of this blog has blocked the current user
 if ($failed == false) {
   $blogOwnerBlockCheck = new BlockManager($thisBlog->ownerID);
   if ($session !== false) {
@@ -34,6 +34,15 @@ if ($failed == false) {
     }
   }
 }
+
+// Check if the current user has blocked the owner of this blog
+if ($failed == false && $session !== false) {
+  $currentUserBlockCheck = new BlockManager($sessionObj->user->ID);
+  if ($currentUserBlockCheck->hasBlockedUser($thisBlog->ownerID)) {
+    $failed = true;
+  }
+}
+
 if ($thisBlog->password != null && (!isset($sessionObj->sessionData['blogLogins'][$thisBlog->ID]) || time() > $sessionObj->sessionData['blogLogins'][$thisBlog->ID])) {
   require_once(__DIR__.'/blogLogin.php');
   exit();


### PR DESCRIPTION
This fixes two blocking-related issues:

- You can no longer view the blogs of users you have blocked
- Posts from users you have blocked will no longer show up in Featured

The modified code for Featured will try 5 times to retrieve a featured post from a user that you have not blocked, and if that fails, it just gives up and doesn't render a featured post.