### PR TITLE
Fix an error in dashboard "featured post" when no featured posts exist

### DIFF
--- a/html/dashboard.php
+++ b/html/dashboard.php
@@ -133,14 +133,22 @@ if (sizeof($posts) == 0) {
 			while ($featuredTries < 5) {
 				$featuredID = WFUtils::selectFeaturedPost();
 				$featuredPost = new Post($featuredID);
-				$featuredBlog = new Blog($featuredPost->onBlog);
-
-				if ($featuredPost->failed || $featuredBlog->failed || $blockManager->hasBlockedUser($featuredBlog->ownerID)) {
+				if ($featuredPost->failed) {
 					$featuredTries += 1;
 					$featuredID = 0;
-				} else {
-					break;
+					continue;
 				}
+				
+				
+				$featuredBlog = new Blog($featuredPost->onBlog);
+
+				if ($featuredBlog->failed || $blockManager->hasBlockedUser($featuredBlog->ownerID)) {
+					$featuredTries += 1;
+					$featuredID = 0;
+					continue;
+				}
+				
+				break;
 			}
 
 			if ($featuredID !== 0 && !$featuredPost->failed && !$featuredBlog->failed) {


### PR DESCRIPTION
If no featured posts exist in the database, or for some reason the featured post that is pulled from the database by the `WFUtils::selectFeaturedPost()` function can not be loaded correctly, the dashboard would show a PHP warning. 

The code was trying to load the `$featuredBlog` from `$featuredPost->onBlog` without actually checking the failure state of `$featuredPost`, leading to `new Blog($featuredPost->onBlog /* === null */)` happening, blowing up in our faces (because the `Blog` constructor expects an `int`). ~~Because we don't use `declare(strict_types=1)` in Waterfall, this is a warning and not an error - so thankfully this blowing up didn't stop the page from rendering.~~ This was actually a fatal error - oops 😨 

This change adds a small safeguard around this, causing another retry for retrieving a featured post, falling back to "not rendering a featured post at all."