### PR TITLE
Make `combinedSort` on the Dashboard work in newer PHP

### DIFF
--- a/html/dashboard.php
+++ b/html/dashboard.php
@@ -108,7 +108,11 @@ if (sizeof($posts) != 0) {
 <?php
 $combinedArray = array_merge($posts, $notes);
 function combinedSort($a, $b) {
-	return (intval($a->timestring) < intval($b->timestring));
+	$a_ts = intval($a->timestring);
+	$b_ts = intval($b->timestring);
+	
+	if ($a_ts == $b_ts) return 0;
+	return ($a_ts < $b_ts) ? 1 : -1;
 }
 usort($combinedArray, 'combinedSort');
 


### PR DESCRIPTION
> **Deprecated**: usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero in **/Users/iris/Projects/Waterfall/html/dashboard.php** on line **116**

This changes the Dashboard's `combinedSort` function (which is then passed to `usort`) to return a value that PHP doesn't complain about. 