### PR TITLE
Yeet `require_once` from `loader.php`, use Composer PSR-0 autoload instead

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         "tgalopin/html-sanitizer": "^1.4"
     },
     "autoload": {
+		"psr-0": {
+			"": "src/"
+		},
         "classmap": [
             "src/"
         ]

--- a/src/loader.php
+++ b/src/loader.php
@@ -1,45 +1,5 @@
 <?php 
-//require_once(__DIR__."/sentry.php");
-//require_once(__DIR__."/database.php");
-require_once(__DIR__."/../vendor/autoload.php");
-require_once(__DIR__."/classes/Postgres.class.php");
-require_once(__DIR__."/classes/WFUtils.class.php");
-require_once(__DIR__."/classes/UIUtils.class.php");
-
-require_once(__DIR__."/classes/WFRedis.class.php");
-require_once(__DIR__."/classes/BlogMember.class.php");
-require_once(__DIR__."/classes/User.class.php");
-require_once(__DIR__."/classes/Blog.class.php");
-require_once(__DIR__."/classes/Tag.class.php");
-require_once(__DIR__."/classes/Post.class.php");
-require_once(__DIR__."/classes/Badge.class.php");
-require_once(__DIR__."/classes/EmailMessage.class.php");
-require_once(__DIR__."/classes/Poll.class.php");
-
-require_once(__DIR__."/classes/Session.class.php");
-require_once(__DIR__."/classes/BlockManager.class.php");
-require_once(__DIR__."/classes/Postgres.class.php");
-require_once(__DIR__."/classes/PostCollector.class.php");
-require_once(__DIR__."/classes/Message.class.php");
-require_once(__DIR__."/classes/Note.class.php");
-require_once(__DIR__."/classes/WFImage.class.php");
-require_once(__DIR__."/classes/WFAvatar.class.php");
-require_once(__DIR__."/classes/WFText.class.php");
-require_once(__DIR__."/classes/WFVideo.class.php");
-require_once(__DIR__."/classes/WFi18n.class.php");
-require_once(__DIR__."/classes/posts/TextPost.class.php");
-require_once(__DIR__."/classes/posts/AnswerPost.class.php");
-require_once(__DIR__."/classes/posts/ImagePost.class.php");
-require_once(__DIR__."/classes/posts/ArtPost.class.php");
-require_once(__DIR__."/classes/posts/AudioPost.class.php");
-require_once(__DIR__."/classes/posts/QuotePost.class.php");
-require_once(__DIR__."/classes/posts/LinkPost.class.php");
-require_once(__DIR__."/classes/posts/VideoPost.class.php");
-require_once(__DIR__."/classes/posts/ChatPost.class.php");
-require_once(__DIR__."/classes/posts/Reblog.class.php");
-require_once(__DIR__."/classes/Page.class.php");
-require_once(__DIR__."/classes/JohnDeLancie.class.php");
-require_once(__DIR__."/modules/Huntress.class.php");
+require_once(dirname(__DIR__) . "/vendor/autoload.php");
 
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
 $dotenv->load();
@@ -63,8 +23,6 @@ if ($_ENV['SENTRY_DSN'] != null && $_ENV['SENTRY_DSN'] != '') {
   \Sentry\init([ 'dsn' => $_ENV['SENTRY_DSN'] ]);
 }
 
-require_once(__DIR__."/classes/Emoji.class.php");
-
 // Set up translations
-$i18n = new \WFi18n(__DIR__.'/../lang/lang_{LANGUAGE}.ini', __DIR__.'/../langcache/', 'en');
+$i18n = new \WFi18n(dirname(__DIR__) . '/lang/lang_{LANGUAGE}.ini', dirname(__DIR__) . '/langcache/', 'en');
 $i18n->init();


### PR DESCRIPTION
This brings a bunch of benefits - most obviously, there's no manual maintenance of the list of requires in `loader.php` anymore. It also might make load times _slightly_ faster, because classes will only get loaded if they are actually used by the page that's currently being requested (rather than just "load all the things") - but I have not benchmarked this, and honestly, there's no need to.

Because PSR-0 is basically just a way for Composer to create a file saying "here's the file that each of these classes is located in," (rather than PSR-4's fancy "I know the name of this class and I can derive a filename from that"), Composer's PSR-0 cache must be updated if you add or rename something in `src/` - you can do this by running `composer dumpautoload`. 

The autoload files are automatically generated when running either of `composer install` / `composer update`, so as long as you're doing that when you deploy the site to production, the process for deployment does not change with this PR.