### PR TITLE
WFText: Rewrite input sanitization and shortcoding

### DIFF
--- a/lang/lang_de.ini
+++ b/lang/lang_de.ini
@@ -61,6 +61,7 @@ success = "Ein Erfolg!"
 posted = "Geposted!"
 updated = "Erfolgreich geupdated!"
 goodbye = "Auf Wiedersehen, space cowboy..."
+read_more = "Weiterlesen"
 
 [dashboard]
 no_posts = "Hier sind keine Beiträge, die wir Dir zeigen könnten. Folgst Du denn schon jemandem?"

--- a/lang/lang_en.ini
+++ b/lang/lang_en.ini
@@ -60,6 +60,7 @@ success = "Success!"
 posted = "Posted!"
 updated = "Updated successfully!"
 goodbye = "See you, space cowboy..."
+read_more = "Read more"
 
 [dashboard]
 no_posts = "No posts to show. Are you following anyone?"

--- a/lang/lang_es.ini
+++ b/lang/lang_es.ini
@@ -59,6 +59,7 @@ success = "Éxito!"
 posted = "Publicado!"
 updated = "Actualizado con éxito!"
 goodbye = "See you, space cowboy..."
+read_more = "Lee mas"
 
 [dashboard]
 no_posts = "No hay publicaciones para mostrar. ¿Estás siguiendo a alguien?"

--- a/src/classes/Page.class.php
+++ b/src/classes/Page.class.php
@@ -62,7 +62,7 @@ class Page {
         $this->onBlog = $onBlog;
         $content = WFText::getInlines($pageText);
         $this->content = str_replace('<hr>', '', $content[0]);
-        $this->content = WFText::makeTextSafe($this->content);
+        $this->content = WFText::makeTextPostContentSafe($this->content);
         $this->inlineImages = $content[1];
         $this->pageTitle = WFText::makeTextSafe($pageTitle);
         $this->url = WFUtils::urlFixer($pageURL);
@@ -82,7 +82,7 @@ class Page {
         $this->onBlog = $onBlog;
         $content = WFText::getInlines($pageText);
         $this->content = str_replace('<hr>', '', $content[0]);
-        $this->content = WFText::makeTextSafe($this->content);
+        $this->content = WFText::makeTextPostContentSafe($this->content);
         $this->inlineImages = $content[1];
         $this->pageTitle = WFText::makeTextSafe($pageTitle);
         $this->url = WFUtils::urlFixer($pageURL);

--- a/src/classes/Post.class.php
+++ b/src/classes/Post.class.php
@@ -169,7 +169,7 @@ class Post {
         $content = WFText::getInlines($this->content);
         $this->inlineImages = $content[1];
 
-        $this->content = WFText::makeTextSafe($content[0]);
+        $this->content = WFText::makeTextPostContentSafe($content[0]);
         $values = array($this->content, $this->postStatus, $this->database->php_to_postgres($this->getTagIDs($this->tags)), $this->database->php_to_postgres($this->imageIDs), $this->ID, $this->postTitle, $this->database->php_to_postgres($this->inlineImages), $this->timestamp);
         $res = $this->database->db_update("UPDATE posts SET post_content = $1, post_status = $2, tags = $3, image_id = $4, post_title = $6, inline_images = $7, timestamp = $8 WHERE id = $5", $values);
         

--- a/src/classes/WFHtmlSanitizer/ANode.php
+++ b/src/classes/WFHtmlSanitizer/ANode.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WFHtmlSanitizer;
+
+use HtmlSanitizer\Node\AbstractTagNode;
+use HtmlSanitizer\Node\HasChildrenTrait;
+
+class ANode extends AbstractTagNode {
+	use HasChildrenTrait;
+
+	public function getTagName(): string {
+		return 'a';
+	}
+
+	public function render(): string {
+		$tag = $this->getTagName();
+
+		// XXX: Return an empty string if we have no children and no content.
+		// 
+		// This is a bit of a hack to make sure that existing post/page content
+		// continues to render correctly with the combination of the new WFText
+		// setup, and the new WFHtmlSanitizer.
+		if (empty($renderedChildren = trim($this->renderChildren()))) {
+			return '';
+		}
+
+		return "<{$tag}{$this->renderAttributes()}>{$renderedChildren}</{$tag}>";
+	}
+}

--- a/src/classes/WFHtmlSanitizer/ANodeVisitor.php
+++ b/src/classes/WFHtmlSanitizer/ANodeVisitor.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace WFHtmlSanitizer;
+
+use HtmlSanitizer\Model\Cursor;
+use HtmlSanitizer\Node\NodeInterface;
+use HtmlSanitizer\Visitor\AbstractNodeVisitor;
+use HtmlSanitizer\Visitor\NamedNodeVisitorInterface;
+use HtmlSanitizer\Visitor\HasChildrenNodeVisitorTrait;
+use HtmlSanitizer\Extension\Basic\Node\ANode;
+
+class ANodeVisitor extends AbstractNodeVisitor implements NamedNodeVisitorInterface {
+	use HasChildrenNodeVisitorTrait;
+
+	protected function getDomNodeName(): string {
+		return 'a';
+	}
+
+	protected function createNode(\DOMNode $domNode, Cursor $cursor): NodeInterface {
+		$node = new ANode($cursor->node);
+
+		// Do we have mention shortcoding enabled?
+		if (array_key_exists('enabled', $this->config['waterfall-shortcodes']) && in_array('mention', $this->config['waterfall-shortcodes']['enabled'] ?? [])) {
+			// Does this image have a `data-url-mentions` attribute?
+			if (!empty($blogName = $this->getAttribute($domNode, 'data-url-mentions'))) {
+				// Yes it does, let's grab the blog from the name
+				$blog = new \Blog();
+				$blog->getByBlogName($blogName);
+				if (!$blog->failed) {
+					// Cool, we have a blog object! Let's do the shortcoding.
+					$newNode = new ShortcodeNode($cursor->node);
+					$newNode->setShortcode('{{MENTION:{{' . $blog->ID . '}}}}');
+					return $newNode;
+				}
+			}
+		}
+
+		return $node;
+	}
+}

--- a/src/classes/WFHtmlSanitizer/ANodeVisitor.php
+++ b/src/classes/WFHtmlSanitizer/ANodeVisitor.php
@@ -7,7 +7,6 @@ use HtmlSanitizer\Node\NodeInterface;
 use HtmlSanitizer\Visitor\AbstractNodeVisitor;
 use HtmlSanitizer\Visitor\NamedNodeVisitorInterface;
 use HtmlSanitizer\Visitor\HasChildrenNodeVisitorTrait;
-use HtmlSanitizer\Extension\Basic\Node\ANode;
 
 class ANodeVisitor extends AbstractNodeVisitor implements NamedNodeVisitorInterface {
 	use HasChildrenNodeVisitorTrait;

--- a/src/classes/WFHtmlSanitizer/HrNodeVisitor.php
+++ b/src/classes/WFHtmlSanitizer/HrNodeVisitor.php
@@ -24,6 +24,7 @@ class HrNodeVisitor extends AbstractNodeVisitor implements NamedNodeVisitorInter
 			// Yes we do, let's shortcode it
 			$newNode = new ShortcodeNode($cursor->node);
 			$newNode->setShortcode('{{READMORE}}');
+			$newNode->setContainShortcode(true);
 			return $newNode;
 		}
 

--- a/src/classes/WFHtmlSanitizer/HrNodeVisitor.php
+++ b/src/classes/WFHtmlSanitizer/HrNodeVisitor.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace WFHtmlSanitizer;
+
+use HtmlSanitizer\Model\Cursor;
+use HtmlSanitizer\Node\NodeInterface;
+use HtmlSanitizer\Visitor\AbstractNodeVisitor;
+use HtmlSanitizer\Visitor\NamedNodeVisitorInterface;
+use HtmlSanitizer\Visitor\IsChildlessTagVisitorTrait;
+use HtmlSanitizer\Extension\Extra\Node\HrNode;
+
+class HrNodeVisitor extends AbstractNodeVisitor implements NamedNodeVisitorInterface {
+	use IsChildlessTagVisitorTrait;
+
+	protected function getDomNodeName(): string {
+		return 'hr';
+	}
+
+	protected function createNode(\DOMNode $domNode, Cursor $cursor): NodeInterface {
+		$node = new HrNode($cursor->node);
+
+		// Do we have read-more shortcoding enabled?
+		if (array_key_exists('enabled', $this->config['waterfall-shortcodes']) && in_array('readmore', $this->config['waterfall-shortcodes']['enabled'] ?? [])) {
+			// Yes we do, let's shortcode it
+			$newNode = new ShortcodeNode($cursor->node);
+			$newNode->setShortcode('{{READMORE}}');
+			return $newNode;
+		}
+
+		return $node;
+	}
+}

--- a/src/classes/WFHtmlSanitizer/ImgNodeVisitor.php
+++ b/src/classes/WFHtmlSanitizer/ImgNodeVisitor.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace WFHtmlSanitizer;
+
+use HtmlSanitizer\Model\Cursor;
+use HtmlSanitizer\Node\NodeInterface;
+use HtmlSanitizer\Visitor\AbstractNodeVisitor;
+use HtmlSanitizer\Visitor\NamedNodeVisitorInterface;
+use HtmlSanitizer\Visitor\IsChildlessTagVisitorTrait;
+use HtmlSanitizer\Extension\Image\Node\ImgNode;
+
+class ImgNodeVisitor extends AbstractNodeVisitor implements NamedNodeVisitorInterface {
+	use IsChildlessTagVisitorTrait;
+
+	protected function getDomNodeName(): string {
+		return 'img';
+	}
+
+	protected function createNode(\DOMNode $domNode, Cursor $cursor): NodeInterface {
+		$node = new ImgNode($cursor->node);
+
+		if ($this->config['override_class'] !== null) {
+			$new_classes = explode(" ", $this->config['override_class']);
+			
+			if ($this->config['preserve_classes'] === true) {
+				$existing_classes = explode(" ", $this->getAttribute($domNode, 'class'));
+				$new_classes = array_unique(array_merge($new_classes, $existing_classes));
+			}
+
+			$node->setAttribute('class', implode(" ", $new_classes));
+		}
+
+		return $node;
+	}
+}

--- a/src/classes/WFHtmlSanitizer/ImgNodeVisitor.php
+++ b/src/classes/WFHtmlSanitizer/ImgNodeVisitor.php
@@ -20,8 +20,14 @@ class ImgNodeVisitor extends AbstractNodeVisitor implements NamedNodeVisitorInte
 		$node = new ImgNode($cursor->node);
 
 		if ($this->config['override_class'] !== null) {
-			$new_classes = explode(" ", $this->config['override_class']);
-			
+			$new_classes = $this->config['override_class'];
+
+			// If our configured `override_class` is _not_ an array, then treat it as
+			// if it was a string, and explode it by the space character
+			if (!is_array($new_classes)) {
+				$new_classes = explode(" ", strval($new_classes));
+			}
+
 			if ($this->config['preserve_classes'] === true) {
 				$existing_classes = explode(" ", $this->getAttribute($domNode, 'class'));
 				$new_classes = array_unique(array_merge($new_classes, $existing_classes));

--- a/src/classes/WFHtmlSanitizer/ImgNodeVisitor.php
+++ b/src/classes/WFHtmlSanitizer/ImgNodeVisitor.php
@@ -28,12 +28,27 @@ class ImgNodeVisitor extends AbstractNodeVisitor implements NamedNodeVisitorInte
 				$new_classes = explode(" ", strval($new_classes));
 			}
 
+			// If we're preserving existing classes on the element …
 			if ($this->config['preserve_classes'] === true) {
+				// … explode the existing class list …
 				$existing_classes = explode(" ", $this->getAttribute($domNode, 'class'));
-				$new_classes = array_unique(array_merge($new_classes, $existing_classes));
+				// … and merge that with the new class list
+				$new_classes = array_merge($new_classes, $existing_classes);
 			}
 
-			$node->setAttribute('class', implode(" ", $new_classes));
+			// Filter out empty values, and remove duplicates, leaving us with a
+			// clean list of classes to apply to the target element
+			$new_classes = array_unique(array_filter($new_classes));
+			
+			if (empty($new_classes)) {
+				// If we have no classes, remove the class attribute - if we don't do
+				// this, the classes that were already on the elemnet will remain, even
+				// in the case of `preserve_classes` not being `true`
+				$node->removeAttribute('class');
+			} else {
+				// But if we do have classes, set the element's class attribute
+				$node->setAttribute('class', implode(" ", $new_classes));
+			}
 		}
 
 		return $node;

--- a/src/classes/WFHtmlSanitizer/ShortcodeNode.php
+++ b/src/classes/WFHtmlSanitizer/ShortcodeNode.php
@@ -13,8 +13,17 @@ class ShortcodeNode extends AbstractNode
 	public function setShortcode(string $shortcode) {
 		$this->shortcode = $shortcode;
 	}
-	
+
+	public bool $containShortcode = false;
+	public function setContainShortcode(bool $containShortcode) {
+		$this->containShortcode = $containShortcode;
+	}
+
 	public function render(): string {
+		if ($this->containShortcode) {
+			return "<p>{$this->shortcode}</p>";
+		}
+
 		return $this->shortcode;
 	}
 }

--- a/src/classes/WFHtmlSanitizer/ShortcodeNode.php
+++ b/src/classes/WFHtmlSanitizer/ShortcodeNode.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace WFHtmlSanitizer;
+
+use HtmlSanitizer\Node\AbstractNode;
+use HtmlSanitizer\Node\IsChildlessTrait;
+
+class ShortcodeNode extends AbstractNode
+{
+	use IsChildlessTrait;
+
+	public string $shortcode;
+	public function setShortcode(string $shortcode) {
+		$this->shortcode = $shortcode;
+	}
+	
+	public function render(): string {
+		return $this->shortcode;
+	}
+}

--- a/src/classes/WFHtmlSanitizer/WFExtension.php
+++ b/src/classes/WFHtmlSanitizer/WFExtension.php
@@ -26,6 +26,7 @@ class WFExtension implements ExtensionInterface {
 
 	public function createNodeVisitors(array $config = []): array {
 		return [
+			'a' => new ANodeVisitor(array_merge($config['tags']['a'] ?? [], ['waterfall-shortcodes' => $config['waterfall-shortcodes'] ?? []])),
 			'img' => new ImgNodeVisitor(array_merge($config['tags']['img'] ?? [], ['waterfall-shortcodes' => $config['waterfall-shortcodes'] ?? []])),
 			'hr' => new HrNodeVisitor(array_merge($config['tags']['hr'] ?? [], ['waterfall-shortcodes' => $config['waterfall-shortcodes'] ?? []])),
 		];

--- a/src/classes/WFHtmlSanitizer/WFExtension.php
+++ b/src/classes/WFHtmlSanitizer/WFExtension.php
@@ -26,7 +26,7 @@ class WFExtension implements ExtensionInterface {
 
 	public function createNodeVisitors(array $config = []): array {
 		return [
-			'img' => new ImgNodeVisitor($config['tags']['img'] ?? []),
+			'img' => new ImgNodeVisitor(array_merge($config['tags']['img'] ?? [], ['waterfall-shortcodes' => $config['waterfall-shortcodes'] ?? []])),
 		];
 	}
 }

--- a/src/classes/WFHtmlSanitizer/WFExtension.php
+++ b/src/classes/WFHtmlSanitizer/WFExtension.php
@@ -27,6 +27,7 @@ class WFExtension implements ExtensionInterface {
 	public function createNodeVisitors(array $config = []): array {
 		return [
 			'img' => new ImgNodeVisitor(array_merge($config['tags']['img'] ?? [], ['waterfall-shortcodes' => $config['waterfall-shortcodes'] ?? []])),
+			'hr' => new HrNodeVisitor(array_merge($config['tags']['hr'] ?? [], ['waterfall-shortcodes' => $config['waterfall-shortcodes'] ?? []])),
 		];
 	}
 }

--- a/src/classes/WFHtmlSanitizer/WFExtension.php
+++ b/src/classes/WFHtmlSanitizer/WFExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Waterfall extensions to HtmlSanitizer.
+ *
+ * To use this extension, register it with a \HtmlSanitizer\SanitizerBuilder
+ * instance, and then pass `'waterfall'` as part of the `'extensions'` array
+ * when performing the HtmlSanitizer build:
+ *
+ * ```php
+ * $sanitizerBuilder = \HtmlSanitizer\SanitizerBuilder::createDefault();
+ * $sanitizerBuilder->registerExtension(new \WFHtmlSanitizer\WFExtension());
+ *
+ * $sanitizer = $sanitizerBuilder->build(['extensions' => [..., 'waterfall']]);
+ * ```
+ */
+
+namespace WFHtmlSanitizer;
+
+use HtmlSanitizer\Extension\ExtensionInterface;
+
+class WFExtension implements ExtensionInterface {
+	public function getName(): string {
+		return 'waterfall';
+	}
+
+	public function createNodeVisitors(array $config = []): array {
+		return [
+			'img' => new ImgNodeVisitor($config['tags']['img'] ?? []),
+		];
+	}
+}

--- a/src/classes/WFText.class.php
+++ b/src/classes/WFText.class.php
@@ -94,6 +94,37 @@ class WFText {
 		]);
 	}
 
+	public static function createUntrustedContentSanitizer(): Sanitizer {
+		/**
+		 * Create an HtmlSanitizer configured to sanitize the living daylights out
+		 * of untrusted input. This sanitizer should always be used for untrusted
+		 * input that is not being used for blog post/page content.
+		 *
+		 * @return A configured HtmlSanitizer
+		 */
+
+		return self::createBaseSanitizer([
+			'tags' => [
+				'a' => [
+					'allowed_attributes' => ['href', 'title'],
+				],
+
+				'img' => [
+					'allowed_attributes' => ['src', 'alt', 'title'],
+
+					// Only allow images loaded from our own servers to pass through the
+					// filter, and always force loading those images over HTTPS
+					'allowed_hosts' => [$_ENV['SITE_URL']],
+					'force_https' => true,
+
+					// Strip all provided classes from image elements
+					'override_class' => '',
+					'preserve_classes' => false,
+				],
+			],
+		]);
+	}
+
     public static function makeTextRenderable($content, $segmentID = 0) {
         /**
 		 * Makes the text of a post segment (or blog page) renderable by the UI,

--- a/src/classes/WFText.class.php
+++ b/src/classes/WFText.class.php
@@ -163,14 +163,14 @@ class WFText {
 		]);
 	}
 
-    public static function makeTextRenderable($content, $segmentID = 0) {
-        /**
+	public static function makeTextRenderable($content, $segmentID = 0) {
+		/**
 		 * Makes the text of a post segment (or blog page) renderable by the UI,
 		 * including HTML sanitization.
 		 * 
 		 * @param content The content to make renderable.
-         * @return The renderable HTML.
-         */
+		 * @return The renderable HTML.
+		 */
 
 		// Create a Parsedown instance
 		$parsedown = (new Parsedown())->setSafeMode(true)->setBreaksEnabled(true);
@@ -283,10 +283,10 @@ class WFText {
 		// strip *everything*, which is what we want.
 		$sanitizer = \HtmlSanitizer\Sanitizer::create(['extensions' => []]);
 		$content = $sanitizer->sanitize($content);
-		
+
 		// Yeet the Zalgo text into the sun, hopefully.
 		$content = preg_replace("~(?:[\p{M}]{1})([\p{M}])~uis", "", $content);
-		
+
 		return $content;
 	}
 
@@ -355,7 +355,7 @@ class WFText {
 				}
 			}
 		}
-		
+
 		// For each entry in the `replacements` array …
 		foreach ($replacements as $strBlogID => $blog) {
 			// … construct a link to the mentioned blog …
@@ -375,7 +375,7 @@ class WFText {
 			// … and replace all occurrences in our `$content` with the link
 			$content = str_replace($replacement_pattern, $replacement_text, $content);
 		}
-		
+
 		// Now, we want to scan for any MENTION short-tags left over (which will be
 		// the result of an invalid blog), and replace them with a mention link
 		// pointing to `unidentified-blog`.
@@ -506,11 +506,7 @@ class WFText {
     return array($text, $inlineImageIDs);
     }
 
-    public static function is_base64($s)
-    {
-          return (bool) preg_match('/^[a-zA-Z0-9\/\r\n+]*={0,2}$/', $s);
-    }
-
-
-
+	public static function is_base64($s) {
+		return (bool) preg_match('/^[a-zA-Z0-9\/\r\n+]+=*$/', $s);
+	}
 }

--- a/src/classes/WFText.class.php
+++ b/src/classes/WFText.class.php
@@ -338,6 +338,10 @@ class WFText {
 		 * @param content The content to search and modify
 		 * @return The modified content
 		 */
+		
+		// Turn on "user error handling" for LibXML, storing the old value so we
+		// can flip it back at the end of the function
+		$libxmlPreviousErrorMode = libxml_use_internal_errors(true);
 
 		$replacements = array();
 
@@ -360,6 +364,7 @@ class WFText {
 		foreach ($replacements as $strBlogID => $blog) {
 			// … construct a link to the mentioned blog …
 			$mentionDoc = new \DOMDocument("1.0");
+			$mentionDoc->encoding = 'UTF-8';
 			$mentionLink = $mentionDoc->createElement('a');
 			$mentionDoc->appendChild($mentionLink);
 			$mentionLink->nodeValue = "@{$blog->blogName}";
@@ -382,6 +387,7 @@ class WFText {
 		if (preg_match($match_regex, $content, $matches)) {
 			// Construct a link to the `unidentified-blog` …
 			$mentionDoc = new \DOMDocument("1.0");
+			$mentionDoc->encoding = 'UTF-8';
 			$mentionLink = $mentionDoc->createElement('a');
 			$mentionDoc->appendChild($mentionLink);
 			$mentionLink->nodeValue = "@unidentified-blog";
@@ -402,6 +408,9 @@ class WFText {
 				$content = str_replace($replacement_pattern, $replacement_text, $content);
 			}
 		}
+
+		// Reset the "user error handling" flag of LibXML.
+		libxml_use_internal_errors($libxmlPreviousErrorMode);
 
 		// And with that, we're done!
 		return $content;

--- a/src/classes/WFText.class.php
+++ b/src/classes/WFText.class.php
@@ -88,30 +88,37 @@ class WFText {
     }
 
     public static function makeTextRenderableForEdit($content, $segmentID = 0) {
-        /** Makes text be HTML formatted. Not necesary, but for safety.
-        * @param content The content to make renderable.
-        * @return result The renderable HMTL.
-        */
-        //$result =  str_replace('\;', ';', $result);
-        $result = $content;
-        //$result = imageReplace($result, $type);
-        $result = str_replace('\"', '"', $result);
-        $result = str_replace("\'", "'", $result);
-        #$result = str_replace('"images/', '"https://'.$_ENV['SITE_URL'].'/images/', $result);
-        #$result = str_replace('"../images/', '"https://'.$_ENV['SITE_URL'].'/images/', $result);
-        $Parsedown = new Parsedown();
-        $Parsedown->setSafeMode(true);
-        $Parsedown->setBreaksEnabled(true);
-        $result = $Parsedown->text($result);
-        $result = WFText::mentionReplace($result);
-        $result = WFText::imageReplace($result);
-        $result = str_replace('{{READMORE}}', '<hr>', $result);
+        /**
+		 * Makes the text of a post segment (or blog page) renderable by the 
+		 * post/page text editor, including HTML sanitization.
+		 * 
+		 * @param content The content to make renderable.
+         * @return The renderable HTML.
+         */
 
-        $result = str_replace('img src', 'img class="img-fluid" src', $result);
-        $result = str_replace('img  src', 'img class="img-fluid" src', $result);
-        $result = str_replace('\\', '', $result);
+		// Create a Parsedown instance
+		$parsedown = (new Parsedown())->setSafeMode(true)->setBreaksEnabled(true);
 
-        return $result;
+		// Create an HtmlSanitizer
+		$sanitizer = self::createDefaultPostSanitizer();
+
+		// Run Parsedown on the input
+		$content = $parsedown->text($content);
+
+		// Replace mentions and images
+		$content = self::mentionReplace($content);
+		$content = self::imageReplace($content);
+
+		// Run the HTML sanitizer
+		//
+		// Note that this should be done AFTER the call to `WFText::imageReplace`
+		// but BEFORE the read-more <hr> replacement below
+		$content = $sanitizer->sanitize($content);
+
+		// Replace read-more with a <hr>
+		$content = str_replace('{{READMORE}}', '<hr>', $content);
+
+		return $content;
     }
       
     public static function makeTextStripped($content, $segmentID = 0) {

--- a/src/classes/WFText.class.php
+++ b/src/classes/WFText.class.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 use \HtmlSanitizer\SanitizerBuilder;
 use \HtmlSanitizer\Sanitizer;
@@ -10,7 +10,7 @@ class WFText {
 		 * Creates a strict HtmlSanitizer for post content, optionally overriding
 		 * the base configuration provided by this function with the passed-in
 		 * options.
-		 * 
+		 *
 		 * @param options HtmlSanitizer option overrides
 		 * @return A configured HtmlSanitizer
 		 */
@@ -167,7 +167,7 @@ class WFText {
 		/**
 		 * Makes the text of a post segment (or blog page) renderable by the UI,
 		 * including HTML sanitization.
-		 * 
+		 *
 		 * @param content The content to make renderable.
 		 * @return The renderable HTML.
 		 */
@@ -204,13 +204,13 @@ class WFText {
     }
 
     public static function makeTextRenderableForEdit($content, $segmentID = 0) {
-        /**
-		 * Makes the text of a post segment (or blog page) renderable by the 
+		/**
+		 * Makes the text of a post segment (or blog page) renderable by the
 		 * post/page text editor, including HTML sanitization.
-		 * 
+		 *
 		 * @param content The content to make renderable.
-         * @return The renderable HTML.
-         */
+		 * @return The renderable HTML.
+		 */
 
 		// Create a Parsedown instance
 		$parsedown = (new Parsedown())->setSafeMode(true)->setBreaksEnabled(true);
@@ -236,16 +236,16 @@ class WFText {
 
 		return $content;
     }
-      
+
     public static function makeTextStripped($content, $segmentID = 0) {
-        /**
+		/**
 		 * Renders a stripped text-only version of the text of a post/page,
 		 * suitable for use in things like Open Graph description tags.
-		 * 
+		 *
 		 * @param content The content to make renderable.
-         * @return The rendered plain text.
-         */
-		
+		 * @return The rendered plain text.
+		 */
+
 		// Run Parsedown on the input
 		$parsedown = (new Parsedown())->setSafeMode(true)->setBreaksEnabled(true);
 		$content = $parsedown->text($content);
@@ -256,13 +256,13 @@ class WFText {
         // strip *everything*, which is what we want.
         $sanitizer = \HtmlSanitizer\Sanitizer::create(['extensions' => []]);
         $content = $sanitizer->sanitize($content);
-		
+
 		// Replace all linebreaks with a single space.
 		$content = str_replace("\n", " ", $content);
 
         return $content;
     }
-	
+
 	public static function makeTextSafe($content) {
 		/**
 		 * Makes the input content "safe" for rendering in most places in the user
@@ -276,7 +276,7 @@ class WFText {
 		 * @param content The content to make "safe"
 		 * @return The "safe" text
 		 */
-		
+
 		// Strip out all HTML.
 		//
 		// HtmlSanitizer at it's default settings (with no extensions) will
@@ -338,7 +338,7 @@ class WFText {
 		 * @param content The content to search and modify
 		 * @return The modified content
 		 */
-		
+
 		// Turn on "user error handling" for LibXML, storing the old value so we
 		// can flip it back at the end of the function
 		$libxmlPreviousErrorMode = libxml_use_internal_errors(true);
@@ -484,7 +484,7 @@ class WFText {
 			$readMoreDoc->appendChild($containerElement);
 			$containerElement->setAttribute('id', "postReadMore{$segmentID}");
 			$containerElement->setAttribute('class', 'collapse');
-			
+
 			// Add the child nodes from `$contentPostDoc` into the `$containerElement`
 			foreach ($contentPostDoc->childNodes as $cid => $child) {
 				$childElement = $contentPostDoc->removeChild($child);
@@ -492,7 +492,7 @@ class WFText {
 			}
 
 			// Set `$postContent` to the combination of `$contentPre` (which is
-			// everything BEFORE the read-more marker) and the HTML dump of the 
+			// everything BEFORE the read-more marker) and the HTML dump of the
 			// `$readMoreDoc` (which contains the show/hide button and the container
 			// that holds everything AFTER the read-more marker).
 			$postContent = implode("\n", [
@@ -514,7 +514,7 @@ class WFText {
 		 * @param content The content to search and modify
 		 * @return The modified content
 		 */
-		
+
 		// Turn on "user error handling" for LibXML, storing the old value so we
 		// can flip it back at the end of the function
 		$libxmlPreviousErrorMode = libxml_use_internal_errors(true);
@@ -586,61 +586,68 @@ class WFText {
 		return $content;
 	}
 
-    public static function getInlines($text) {
-        $database = Postgres::getInstance();
-        $htmlDom = new DOMDocument();
-        $htmlDom->loadHTML('<?xml encoding="utf-8" ?>'.$text, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
-        $htmlDomRef = new DOMDocument();
-        $htmlDomRef->loadHTML('<?xml encoding="utf-8" ?>'.$text, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
-        $imageTags = $htmlDom->getElementsByTagName('img');
-        $inlineImageIDs = array();
-        $imageRefs = $htmlDomRef->getElementsByTagName('img');
+	public static function getInlines($text) {
+		$database = Postgres::getInstance();
+		$htmlDom = new DOMDocument();
+		$htmlDom->loadHTML('<?xml encoding="utf-8" ?>'.$text, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+		$htmlDomRef = new DOMDocument();
+		$htmlDomRef->loadHTML('<?xml encoding="utf-8" ?>'.$text, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+		$imageTags = $htmlDom->getElementsByTagName('img');
+		$inlineImageIDs = array();
+		$imageRefs = $htmlDomRef->getElementsByTagName('img');
 
-        foreach($imageRefs as $key => $imageTag){
-            $extractedImage = $imageTag->getAttribute('src');
-            if (base64_decode($extractedImage) !== false) {
-                $randStr = WFUtils::generateRandomString(6);
-                file_put_contents('/tmp/phpfilepostimg'.$randStr, file_get_contents($extractedImage));
-                $ch = curl_init();
-                curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-                $server = WFUtils::pickServer();
-                $url = $server.'/image/add';
-                curl_setopt($ch, CURLOPT_URL, $url);
-                $postData = array();
-                $postData['images'] = new CurlFile("/tmp/phpfilepostimg".$randStr);
-                curl_setopt($ch, CURLOPT_POSTFIELDS, $postData);
-                curl_setopt($ch,CURLOPT_TIMEOUT,100);
-                $chResponse = curl_exec($ch);
-                $json = json_decode($chResponse, true);
-                unset($data);
-                $data = array();
-                if (isset($json['imgData'])) {
-                    $data = $json['imgData'];
-                    $onServer = array($json['onServer']);
-                    $values = array(json_encode($data), 'f', $database->php_to_postgres($onServer));
-                    $imageID = $database->db_insert("INSERT INTO images (paths, is_art, servers, version) VALUES ($1,$2,$3,2)", $values);
-                } else {
-                    $imageID = 0;
-                    $failedImages[] = $extractedImage;
+		foreach($imageRefs as $key => $imageTag){
+			$extractedImage = $imageTag->getAttribute('src');
+			if (base64_decode($extractedImage) !== false) {
+				$randStr = WFUtils::generateRandomString(6);
+				file_put_contents('/tmp/phpfilepostimg'.$randStr, file_get_contents($extractedImage));
+				$ch = curl_init();
+				curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+				$server = WFUtils::pickServer();
+				$url = $server.'/image/add';
+				curl_setopt($ch, CURLOPT_URL, $url);
+				$postData = array();
+				$postData['images'] = new CurlFile("/tmp/phpfilepostimg".$randStr);
+				curl_setopt($ch, CURLOPT_POSTFIELDS, $postData);
+				curl_setopt($ch,CURLOPT_TIMEOUT,100);
+				$chResponse = curl_exec($ch);
+				$json = json_decode($chResponse, true);
+				unset($data);
+				$data = array();
+				if (isset($json['imgData'])) {
+					$data = $json['imgData'];
+					$onServer = array($json['onServer']);
+					$values = array(json_encode($data), 'f', $database->php_to_postgres($onServer));
+					$imageID = $database->db_insert("INSERT INTO images (paths, is_art, servers, version) VALUES ($1,$2,$3,2)", $values);
+				} else {
+					$imageID = 0;
+					$failedImages[] = $extractedImage;
                 }
-                $inlineImageIDs[] = $imageID;
-                $imageText = $htmlDom->createTextNode('{{IMAGE:{{'.$imageID.'}}}}');
-                $imageTags[0]->parentNode->replaceChild($imageText, $imageTags[0]);
-            } elseif ($imageTag->hasAttribute('data-image-id')) {
-                $imageID = $imageTag->getAttribute('data-image-id');
-                $inlineImageIDs[] = $imageID;
-                $imageText = $htmlDom->createTextNode('{{IMAGE:{{'.$imageID.'}}}}');
-                $imageTags[0]->parentNode->replaceChild($imageText, $imageTags[0]);
-            }
-        }
-        foreach ($htmlDom->childNodes as $item)
-            if ($item->nodeType == XML_PI_NODE)
-                $htmlDom->removeChild($item); // remove hack
-        $htmlDom->encoding = 'UTF-8'; // insert proper
-        $text = $htmlDom->saveHTML();
 
-    
-    return array($text, $inlineImageIDs);
+				$inlineImageIDs[] = $imageID;
+				$imageText = $htmlDom->createTextNode('{{IMAGE:{{'.$imageID.'}}}}');
+				$imageTags[0]->parentNode->replaceChild($imageText, $imageTags[0]);
+
+			} elseif ($imageTag->hasAttribute('data-image-id')) {
+				$imageID = $imageTag->getAttribute('data-image-id');
+				$inlineImageIDs[] = $imageID;
+				$imageText = $htmlDom->createTextNode('{{IMAGE:{{'.$imageID.'}}}}');
+				$imageTags[0]->parentNode->replaceChild($imageText, $imageTags[0]);
+			}
+		}
+
+		// Remove hack
+		foreach ($htmlDom->childNodes as $item) {
+			if ($item->nodeType == XML_PI_NODE) {
+				$htmlDom->removeChild($item);
+			}
+		}
+
+		// Insert proper
+		$htmlDom->encoding = 'UTF-8';
+		$text = $htmlDom->saveHTML();
+
+		return array($text, $inlineImageIDs);
     }
 
 	public static function is_base64($s) {

--- a/src/classes/WFText.class.php
+++ b/src/classes/WFText.class.php
@@ -122,8 +122,17 @@ class WFText {
     }
       
     public static function makeTextStripped($content, $segmentID = 0) {
-        // Render as for edit
-        $content = self::makeTextRenderableForEdit($content, $segmentID);
+        /**
+		 * Renders a stripped text-only version of the text of a post/page,
+		 * suitable for use in things like Open Graph description tags.
+		 * 
+		 * @param content The content to make renderable.
+         * @return The rendered plain text.
+         */
+		
+		// Run Parsedown on the input
+		$parsedown = (new Parsedown())->setSafeMode(true)->setBreaksEnabled(true);
+		$content = $parsedown->text($content);
 
         // Strip out all HTML.
         //
@@ -131,6 +140,9 @@ class WFText {
         // strip *everything*, which is what we want.
         $sanitizer = \HtmlSanitizer\Sanitizer::create(['extensions' => []]);
         $content = $sanitizer->sanitize($content);
+		
+		// Replace all linebreaks with a single space.
+		$content = str_replace("\n", " ", $content);
 
         return $content;
     }

--- a/src/classes/WFText.class.php
+++ b/src/classes/WFText.class.php
@@ -1,6 +1,51 @@
 <?php 
 
 class WFText {
+	public static function createDefaultPostSanitizer() {
+		$sanitizerBuilder = \HtmlSanitizer\SanitizerBuilder::createDefault();
+		$sanitizerBuilder->registerExtension(new \WFHtmlSanitizer\WFExtension());
+
+		return $sanitizerBuilder->build([
+			'extensions' => [
+				// Selected HtmlSanitizer defaults
+				'basic', 'list', 'image', 'code', 'details', 'extra',
+
+				// Waterfall extensions
+				'waterfall',
+			],
+
+			'tags' => [
+				'a' => [
+					'allowed_attributes' => [
+						// Standard stuff
+						'href', 'id', 'class', 'width',
+						
+						// Mentions
+						'data-url-mentions',
+						
+						// Lightbox stuff
+						'data-caption', 'data-fancybox',
+					 ],					
+				],
+
+				'img' => [
+					'allowed_attributes' => ['src', 'alt', 'title', 'class', 'data-image-id'],
+
+					// Only allow images loaded from our own servers to pass through the filter
+					'allowed_hosts' => [$_ENV['SITE_URL']],
+
+					// Always use HTTPS
+					'force_https' => true,
+
+					// Always add the `img-fluid` class to images
+					'override_class' => "img-fluid",
+					
+					// Preserve the classes already on the image
+					'preserve_classes' => true,
+				],
+			],
+		]);
+	}
 
     public static function makeTextRenderable($content, $segmentID = 0) {
         /** Makes text be HTML formatted. Not necesary, but for safety.

--- a/src/classes/WFText.class.php
+++ b/src/classes/WFText.class.php
@@ -224,6 +224,33 @@ class WFText {
 
         return $content;
     }
+	
+	public static function makeTextSafe($content) {
+		/**
+		 * Makes the input content "safe" for rendering in most places in the user
+		 * interface, by stripping literally everything from it.
+		 *
+		 * Do not use this for post or page content, or anything that should retain
+		 * markup (use the `makeTextPostContentSafe` function for that) - because
+		 * everything you love about the input markup will be gone from the return
+		 * value.
+		 *
+		 * @param content The content to make "safe"
+		 * @return The "safe" text
+		 */
+		
+		// Strip out all HTML.
+		//
+		// HtmlSanitizer at it's default settings (with no extensions) will
+		// strip *everything*, which is what we want.
+		$sanitizer = \HtmlSanitizer\Sanitizer::create(['extensions' => []]);
+		$content = $sanitizer->sanitize($content);
+		
+		// Yeet the Zalgo text into the sun, hopefully.
+		$content = preg_replace("~(?:[\p{M}]{1})([\p{M}])~uis", "", $content);
+		
+		return $content;
+	}
 
     public static function shorttagMentionRender($content) {
 		/**
@@ -343,40 +370,6 @@ class WFText {
         }
         return $postContent;
       }
-
-      public static function makeTextSafe($content) {
-        /** Makes text safe to store.
-        *
-        * @param content The content to make safe.
-        * @return result The safe text.
-        */
-        $result = $content;
-        $result = nl2br($result);
-
-        $result = str_replace('<div>', '<p>', $result);
-        $result = str_replace('</div>', '</p>', $result);
-        $result = preg_replace('/\bon\w+=\S+(?=.*>)/', '', $result);
-        $result = str_replace('<p><a href', '<div><a href', $result);
-        $result = str_replace('</a></p>', '</a></div>', $result);
-        $result = str_replace('("', '(   "', $result);
-        $result = str_replace('")', '"   )', $result);
-        // MCE
-        $result =  preg_replace('/<hr \/>/', '{{READMORE}}', $result, 1);
-        $result =  preg_replace('/<hr>/', '{{READMORE}}', $result, 1);
-               $converter = new League\HTMLToMarkdown\HtmlConverter(array(
-          'strip_tags' => true
-        ));
-        $result = $converter->convert($result);
-        $result = str_replace("\_", "_", $result);
-        $result = str_replace('("', '(', $result);
-        $result = str_replace('")', ')', $result);
-        $result = str_replace('"   )', '")', $result);
-        $result = str_replace('(   "', '("', $result);
-        $result = preg_replace("~(?:[\p{M}]{1})([\p{M}])~uis","", $result);
-
-        $result = substr($result, 0, 35000);
-        return $result;
-    }
 
     public static function getInlines($text) {
         $database = Postgres::getInstance();

--- a/src/classes/WFUtils.class.php
+++ b/src/classes/WFUtils.class.php
@@ -178,7 +178,8 @@ class WFUtils {
             "internals",
             "waterfall",
             "theoverseerproject",
-            "departmentofapprovals"
+            "departmentofapprovals",
+			"unidentified-blog",
         );
         $blogName = WFUtils::urlFixer($blogName);
         $blogName = strtolower($blogName);

--- a/src/classes/WFUtils.class.php
+++ b/src/classes/WFUtils.class.php
@@ -8,6 +8,34 @@
 */
 
 class WFUtils {
+	/** @var string[] RESTRICTED_BLOG_NAMES */
+	const RESTRICTED_BLOG_NAMES = [
+		"staff",
+		"mail",
+		"api",
+		"analytics",
+		"commissions",
+		"waterfall",
+		"glacier",
+		"security",
+		"www",
+		"testing",
+		"support",
+		"assets",
+		"media",
+		"cdn",
+		"labs",
+		"developers",
+		"dev",
+		"status",
+		"internal",
+		"internals",
+		"waterfall",
+		"theoverseerproject",
+		"departmentofapprovals",
+		"unidentified-blog",
+	];
+
     // All functions should be public static.
 
     public static function detectMobile() {
@@ -144,57 +172,34 @@ class WFUtils {
           }
     }
 
-    public static function blogNameCheck($blogName) {
-        /** Checks whether a blog name is taken or not. Runs through urlFixer().
-        *
-        * @param blogName The blog name.
-        * @return true if the name can be useD
-        * @return false if it's taken.
-        */
-        if (strlen($blogName) < 3) {
-            return false;
-        }
-        # Array of names we don't want them to be able to have. 
-        $restrictedArray = array(
-            "staff",
-            "mail",
-            "api",
-            "analytics",
-            "commissions",
-            "waterfall",
-            "glacier",
-            "security",
-            "www",
-            "testing",
-            "support",
-            "assets",
-            "media",
-            "cdn",
-            "labs",
-            "developers",
-            "dev",
-            "status",
-            "internal",
-            "internals",
-            "waterfall",
-            "theoverseerproject",
-            "departmentofapprovals",
-			"unidentified-blog",
-        );
-        $blogName = WFUtils::urlFixer($blogName);
-        $blogName = strtolower($blogName);
-        $database = Postgres::getInstance();
-        $query = "SELECT * FROM blogs WHERE blog_name = $1;";
-        $values = array($blogName);
-        $blogRow = $database->db_select($query, $values);
-        if ($blogRow) {
-            return false;
-        } elseif (in_array($blogName, $restrictedArray)) {
-            return false;
-        } else {
-            return true;
-        }  
-    }
+	public static function blogNameCheck(string $blogName) {
+		/**
+		 * Checks whether a blog name is taken or not. Runs through urlFixer().
+		 *
+		 * @param blogName The blog name
+		 * @return bool Whether the name can be used
+		 */
+
+		// Sanitize the blog name
+		$blogName = WFUtils::urlFixer($blogName);
+		$blogName = strtolower($blogName);
+
+		// Bail early if under three characters
+		if (strlen($blogName) < 3) {
+			return false;
+		}
+
+		// Bail early if it's a restricted name
+		if (in_array($blogName, self::RESTRICTED_BLOG_NAMES)) {
+			return false;
+		}
+
+		// Check the database for a blog with this name
+		$database = Postgres::getInstance();
+		$query = "SELECT * FROM blogs WHERE blog_name = $1;";
+		$blogRow = $database->db_select($query, [$blogName]);
+		return !$blogRow;
+	}
 
     public static function withinPercent($percentage, $desiredValue, $valueToCheck) {
         /** Checks whether a number is within a percentage range.

--- a/src/classes/posts/AnswerPost.class.php
+++ b/src/classes/posts/AnswerPost.class.php
@@ -10,7 +10,7 @@ class AnswerPost extends Post {
         $this->database = Postgres::getInstance();
         $this->createTags($postTags);
         $content = WFText::getInlines($postText);
-        $this->content = WFText::makeTextSafe($content[0]);
+        $this->content = WFText::makeTextPostContentSafe($content[0]);
         $this->inlineImages = $content[1];
         $this->postTitle = '';
         $this->onBlog = $onBlog;

--- a/src/classes/posts/ArtPost.class.php
+++ b/src/classes/posts/ArtPost.class.php
@@ -9,7 +9,7 @@ class ArtPost extends Post {
         $this->database = Postgres::getInstance();
         $this->createTags($postTags);
         $content = WFText::getInlines($postText);
-        $this->content = WFText::makeTextSafe($content[0]);
+        $this->content = WFText::makeTextPostContentSafe($content[0]);
         $this->inlineImages = $content[1];
         $this->postTitle = WFText::makeTextSafe($postTitle);
         $this->onBlog = $onBlog;

--- a/src/classes/posts/AudioPost.class.php
+++ b/src/classes/posts/AudioPost.class.php
@@ -12,7 +12,7 @@ class AudioPost extends Post {
         $this->database = Postgres::getInstance();
         $this->createTags($postTags);
         $content = WFText::getInlines($postText);
-        $this->content = WFText::makeTextSafe($content[0]);
+        $this->content = WFText::makeTextPostContentSafe($content[0]);
         $this->inlineImages = $content[1];
         $this->postTitle = WFText::makeTextSafe($postTitle);
         $this->onBlog = $onBlog;

--- a/src/classes/posts/ChatPost.class.php
+++ b/src/classes/posts/ChatPost.class.php
@@ -9,7 +9,7 @@ class ChatPost extends Post {
         $this->createTags($postTags);
         $content = WFText::getInlines($postText);
 
-        $this->content = WFText::makeTextSafe($content[0]);
+        $this->content = WFText::makeTextPostContentSafe($content[0]);
         $this->inlineImages = $content[1];
         $this->postTitle = WFText::makeTextSafe($postTitle);
         $this->onBlog = $onBlog;

--- a/src/classes/posts/ImagePost.class.php
+++ b/src/classes/posts/ImagePost.class.php
@@ -9,7 +9,7 @@ class ImagePost extends Post {
         $this->database = Postgres::getInstance();
         $this->createTags($postTags);
         $content = WFText::getInlines($postText);
-        $this->content = WFText::makeTextSafe($content[0]);
+        $this->content = WFText::makeTextPostContentSafe($content[0]);
         $this->inlineImages = $content[1];
         $this->postTitle = WFText::makeTextSafe($postTitle);
         $this->onBlog = $onBlog;

--- a/src/classes/posts/LinkPost.class.php
+++ b/src/classes/posts/LinkPost.class.php
@@ -9,7 +9,7 @@ class LinkPost extends Post {
         $this->database = Postgres::getInstance();
         $this->createTags($postTags);
         $content = WFText::getInlines($postText);
-        $this->content = WFText::makeTextSafe($content[0]);
+        $this->content = WFText::makeTextPostContentSafe($content[0]);
         $this->inlineImages = $content[1];
         $this->postTitle = WFText::makeTextSafe($postTitle);
         $this->onBlog = $onBlog;

--- a/src/classes/posts/QuotePost.class.php
+++ b/src/classes/posts/QuotePost.class.php
@@ -9,7 +9,7 @@ class QuotePost extends Post {
         $this->database = Postgres::getInstance();
         $this->createTags($postTags);
         $content = WFText::getInlines($postText);
-        $this->content = WFText::makeTextSafe($content[0]);
+        $this->content = WFText::makeTextPostContentSafe($content[0]);
         $this->inlineImages = $content[1];
         $postQuote = WFText::makeTextSafe($quote);
         $attribution = WFText::makeTextSafe($attrib);

--- a/src/classes/posts/Reblog.class.php
+++ b/src/classes/posts/Reblog.class.php
@@ -10,7 +10,7 @@ class Reblog extends Post {
         $this->createTags($postTags);
         $content = WFText::getInlines($postText);
 
-        $this->content = WFText::makeTextSafe($content[0]);
+        $this->content = WFText::makeTextPostContentSafe($content[0]);
         $this->inlineImages = $content[1];
         $this->onBlog = $onBlog;
         $this->postStatus = 'posted';

--- a/src/classes/posts/TextPost.class.php
+++ b/src/classes/posts/TextPost.class.php
@@ -9,7 +9,7 @@ class TextPost extends Post {
         $this->database = Postgres::getInstance();
         $this->createTags($postTags);
         $content = WFText::getInlines($postText);
-        $this->content = WFText::makeTextSafe($content[0]);
+        $this->content = WFText::makeTextPostContentSafe($content[0]);
         $this->inlineImages = $content[1];
         $this->postTitle = WFText::makeTextSafe($postTitle);
         $this->onBlog = $onBlog;

--- a/src/classes/posts/VideoPost.class.php
+++ b/src/classes/posts/VideoPost.class.php
@@ -12,7 +12,7 @@ class VideoPost extends Post {
         $this->database = Postgres::getInstance();
         $this->createTags($postTags);
         $content = WFText::getInlines($postText);
-        $this->content = WFText::makeTextSafe($content[0]);
+        $this->content = WFText::makeTextPostContentSafe($content[0]);
         $this->inlineImages = $content[1];
         $this->postTitle = WFText::makeTextSafe($postTitle);
         $this->onBlog = $onBlog;

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -1,6 +1,6 @@
-<?php declare(strict_types=1);
-require_once(__DIR__.'/../src/loader.php');
-require_once(__DIR__."/../vendor/autoload.php");
+<?php
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 
 final class UserTest extends TestCase {

--- a/tests/WFHtmlSanitizer/WFHtmlSanitizerHrTest.php
+++ b/tests/WFHtmlSanitizer/WFHtmlSanitizerHrTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+require_once(dirname(dirname(__DIR__)) . "/vendor/autoload.php");
+
+use PHPUnit\Framework\TestCase;
+use HtmlSanitizer\SanitizerBuilder;
+use WFHtmlSanitizer\WFExtension;
+
+final class WFHtmlSanitizerHrTest extends TestCase {
+	public function testReadMoreShortcodingNormal() {
+		// Construct the sanitizer
+		$sanitizerBuilder = SanitizerBuilder::createDefault();
+		$sanitizerBuilder->registerExtension(new WFExtension());
+		$sanitizer = $sanitizerBuilder->build([
+			'extensions' => ['waterfall'],
+			'waterfall-shortcodes' => ['enabled' => ['readmore']],
+		]);
+
+		// Run the sanitizer
+		$inputData = '<hr>';
+		$outputData = $sanitizer->sanitize($inputData);
+
+		// Verify the output
+		$this->assertEquals($outputData, '{{READMORE}}');
+	}
+
+	public function testReadMoreShortcodingClosingSlash() {
+		// Construct the sanitizer
+		$sanitizerBuilder = SanitizerBuilder::createDefault();
+		$sanitizerBuilder->registerExtension(new WFExtension());
+		$sanitizer = $sanitizerBuilder->build([
+			'extensions' => ['waterfall'],
+			'waterfall-shortcodes' => ['enabled' => ['readmore']],
+		]);
+
+		// Run the sanitizer
+		$inputData = '<hr />';
+		$outputData = $sanitizer->sanitize($inputData);
+
+		// Verify the output
+		$this->assertEquals($outputData, '{{READMORE}}');
+	}
+}

--- a/tests/WFHtmlSanitizer/WFHtmlSanitizerHrTest.php
+++ b/tests/WFHtmlSanitizer/WFHtmlSanitizerHrTest.php
@@ -17,11 +17,11 @@ final class WFHtmlSanitizerHrTest extends TestCase {
 		]);
 
 		// Run the sanitizer
-		$inputData = '<hr>';
+		$inputData = '<p>Test paragraph before read more</p><hr><p>Test paragraph after read more</p>';
 		$outputData = $sanitizer->sanitize($inputData);
 
 		// Verify the output
-		$this->assertEquals($outputData, '{{READMORE}}');
+		$this->assertNotFalse(strpos($outputData, '{{READMORE}}'));
 	}
 
 	public function testReadMoreShortcodingClosingSlash() {
@@ -34,10 +34,27 @@ final class WFHtmlSanitizerHrTest extends TestCase {
 		]);
 
 		// Run the sanitizer
-		$inputData = '<hr />';
+		$inputData = '<p>Test paragraph before read more</p><hr /><p>Test paragraph after read more</p>';
 		$outputData = $sanitizer->sanitize($inputData);
 
 		// Verify the output
-		$this->assertEquals($outputData, '{{READMORE}}');
+		$this->assertNotFalse(strpos($outputData, '{{READMORE}}'));
+	}
+	
+	public function testReadMoreDoesNotShortcodeWhenNotEnabled() {
+		// Construct the sanitizer
+		$sanitizerBuilder = SanitizerBuilder::createDefault();
+		$sanitizerBuilder->registerExtension(new WFExtension());
+		$sanitizer = $sanitizerBuilder->build([
+			'extensions' => ['waterfall'],
+			'waterfall-shortcodes' => ['enabled' => []],
+		]);
+
+		// Run the sanitizer
+		$inputData = '<p>Test paragraph before read more</p><hr><p>Test paragraph after read more</p>';
+		$outputData = $sanitizer->sanitize($inputData);
+
+		// Verify the output
+		$this->assertFalse(strpos($outputData, '{{READMORE}}'));
 	}
 }

--- a/tests/WFHtmlSanitizer/WFHtmlSanitizerHrTest.php
+++ b/tests/WFHtmlSanitizer/WFHtmlSanitizerHrTest.php
@@ -1,6 +1,5 @@
 <?php
 declare(strict_types=1);
-require_once(dirname(dirname(__DIR__)) . "/vendor/autoload.php");
 
 use PHPUnit\Framework\TestCase;
 use HtmlSanitizer\SanitizerBuilder;

--- a/tests/WFHtmlSanitizer/WFHtmlSanitizerImageTest.php
+++ b/tests/WFHtmlSanitizer/WFHtmlSanitizerImageTest.php
@@ -23,6 +23,23 @@ final class WFHtmlSanitizerImageTest extends TestCase {
 		// Verify the output
 		$this->assertEquals($outputData, '{{IMAGE:{{11}}}}');
 	}
+
+	public function testImageDoesNotShortcodeWhenNotEnabled() {
+		// Construct the sanitizer
+		$sanitizerBuilder = SanitizerBuilder::createDefault();
+		$sanitizerBuilder->registerExtension(new WFExtension());
+		$sanitizer = $sanitizerBuilder->build([
+			'extensions' => ['waterfall'],
+			'waterfall-shortcodes' => ['enabled' => []],
+		]);
+
+		// Run the sanitizer
+		$inputData = '<img class="img-fluid mx-auto" data-image-id="11" src="https://01.media.waterfall.test/images/00/wfraven_00_1280.webp">';
+		$outputData = $sanitizer->sanitize($inputData);
+
+		// Verify the output
+		$this->assertFalse(strpos($outputData, '{{IMAGE:{{'));
+	}
 	
 	public function testImageDoesNotShortcodeWithoutImageID() {
 		// Construct the sanitizer

--- a/tests/WFHtmlSanitizer/WFHtmlSanitizerImageTest.php
+++ b/tests/WFHtmlSanitizer/WFHtmlSanitizerImageTest.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types=1);
-require_once(dirname(__DIR__) . "/vendor/autoload.php");
+require_once(dirname(dirname(__DIR__)) . "/vendor/autoload.php");
 
 use PHPUnit\Framework\TestCase;
 use HtmlSanitizer\SanitizerBuilder;

--- a/tests/WFHtmlSanitizer/WFHtmlSanitizerImageTest.php
+++ b/tests/WFHtmlSanitizer/WFHtmlSanitizerImageTest.php
@@ -23,4 +23,21 @@ final class WFHtmlSanitizerImageTest extends TestCase {
 		// Verify the output
 		$this->assertEquals($outputData, '{{IMAGE:{{11}}}}');
 	}
+	
+	public function testImageDoesNotShortcodeWithoutImageID() {
+		// Construct the sanitizer
+		$sanitizerBuilder = SanitizerBuilder::createDefault();
+		$sanitizerBuilder->registerExtension(new WFExtension());
+		$sanitizer = $sanitizerBuilder->build([
+			'extensions' => ['waterfall'],
+			'waterfall-shortcodes' => ['enabled' => ['image']],
+		]);
+
+		// Run the sanitizer
+		$inputData = '<img class="img-fluid mx-auto" src="https://01.media.waterfall.test/images/00/wfraven_00_1280.webp">';
+		$outputData = $sanitizer->sanitize($inputData);
+
+		// Verify the output
+		$this->assertFalse(strpos($outputData, '{{IMAGE:{{'));
+	}
 }

--- a/tests/WFHtmlSanitizer/WFHtmlSanitizerImageTest.php
+++ b/tests/WFHtmlSanitizer/WFHtmlSanitizerImageTest.php
@@ -1,6 +1,5 @@
 <?php
 declare(strict_types=1);
-require_once(dirname(dirname(__DIR__)) . "/vendor/autoload.php");
 
 use PHPUnit\Framework\TestCase;
 use HtmlSanitizer\SanitizerBuilder;

--- a/tests/WFHtmlSanitizer/WFHtmlSanitizerLinkTest.php
+++ b/tests/WFHtmlSanitizer/WFHtmlSanitizerLinkTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+require_once(dirname(dirname(__DIR__)) . "/vendor/autoload.php");
+
+use PHPUnit\Framework\TestCase;
+use HtmlSanitizer\SanitizerBuilder;
+use WFHtmlSanitizer\WFExtension;
+
+final class WFHtmlSanitizerLinkTest extends TestCase {
+	public function testMentionShortcoding() {
+		// Construct the sanitizer
+		$sanitizerBuilder = SanitizerBuilder::createDefault();
+		$sanitizerBuilder->registerExtension(new WFExtension());
+		$sanitizer = $sanitizerBuilder->build([
+			'extensions' => ['waterfall'],
+			'waterfall-shortcodes' => ['enabled' => ['mention']],
+		]);
+
+		// Run the sanitizer
+		$inputData = '<a data-url-mentions="test" href="https://test.waterfall.test">@test</a>';
+		$outputData = $sanitizer->sanitize($inputData);
+
+		// Verify the output
+		$this->assertNotFalse(strpos($outputData, '{{MENTION:{{'));
+	}
+
+	public function testImageDoesNotShortcodeWhenNotEnabled() {
+		// Construct the sanitizer
+		$sanitizerBuilder = SanitizerBuilder::createDefault();
+		$sanitizerBuilder->registerExtension(new WFExtension());
+		$sanitizer = $sanitizerBuilder->build([
+			'extensions' => ['waterfall'],
+			'waterfall-shortcodes' => ['enabled' => []],
+		]);
+
+		// Run the sanitizer
+		$inputData = '<a data-url-mentions="test" href="https://test.waterfall.test">@test</a>';
+		$outputData = $sanitizer->sanitize($inputData);
+
+		// Verify the output
+		$this->assertFalse(strpos($outputData, '{{MENTION:{{'));
+	}
+	
+	public function testImageDoesNotShortcodeWithoutUrlMentions() {
+		// Construct the sanitizer
+		$sanitizerBuilder = SanitizerBuilder::createDefault();
+		$sanitizerBuilder->registerExtension(new WFExtension());
+		$sanitizer = $sanitizerBuilder->build([
+			'extensions' => ['waterfall'],
+			'waterfall-shortcodes' => ['enabled' => ['image']],
+		]);
+
+		// Run the sanitizer
+		$inputData = '<a href="https://test.waterfall.test">@test</a>';
+		$outputData = $sanitizer->sanitize($inputData);
+
+		// Verify the output
+		$this->assertFalse(strpos($outputData, '{{MENTION:{{'));
+	}
+}

--- a/tests/WFHtmlSanitizer/WFHtmlSanitizerLinkTest.php
+++ b/tests/WFHtmlSanitizer/WFHtmlSanitizerLinkTest.php
@@ -1,6 +1,5 @@
 <?php
 declare(strict_types=1);
-require_once(dirname(dirname(__DIR__)) . "/vendor/autoload.php");
 
 use PHPUnit\Framework\TestCase;
 use HtmlSanitizer\SanitizerBuilder;

--- a/tests/WFHtmlSanitizerImageTest.php
+++ b/tests/WFHtmlSanitizerImageTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+require_once(dirname(__DIR__) . "/vendor/autoload.php");
+
+use PHPUnit\Framework\TestCase;
+use HtmlSanitizer\SanitizerBuilder;
+use WFHtmlSanitizer\WFExtension;
+
+final class WFHtmlSanitizerImageTest extends TestCase {
+	public function testImageShortcoding() {
+		// Construct the sanitizer
+		$sanitizerBuilder = SanitizerBuilder::createDefault();
+		$sanitizerBuilder->registerExtension(new WFExtension());
+		$sanitizer = $sanitizerBuilder->build([
+			'extensions' => ['waterfall'],
+			'waterfall-shortcodes' => ['enabled' => ['image']],
+		]);
+
+		// Run the sanitizer
+		$inputData = '<img class="img-fluid mx-auto" data-image-id="11" src="https://01.media.waterfall.test/images/00/wfraven_00_1280.webp">';
+		$outputData = $sanitizer->sanitize($inputData);
+
+		// Verify the output
+		$this->assertEquals($outputData, '{{IMAGE:{{11}}}}');
+	}
+}

--- a/tests/WFText/WFTextMakeTextTest.php
+++ b/tests/WFText/WFTextMakeTextTest.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class WFTextMakeTextTest extends TestCase {
+	public function testMakeTextStrippedReturnsOneLine() {
+		$outputData = WFText::makeTextStripped(implode("\n", [
+			"**Test strong**",
+			"",
+			"0. Test list item",
+			"0. Test list item",
+			"0. Test list item",
+			"0. Test list item",
+			"0. Test list item",
+			"",
+			"**Test strong**",
+		]));
+
+		$this->assertFalse(strpos($outputData, "\n"));
+	}
+
+	public function testMakeTextStrippedContainsNoHtml() {
+		$outputData = WFText::makeTextStripped(implode("\n", [
+			"**Test strong**",
+			"",
+			"0. Test list item",
+			"0. Test list item",
+			"0. Test list item",
+			"0. Test list item",
+			"0. Test list item",
+			"",
+			"**Test strong**",
+		]));
+
+		// If the above was rendered with HTML, we should expect at the least
+		// a <ul> and some <li>, plus a <strong>. Check for those.
+		$this->assertFalse(strpos($outputData, "<ul>"));
+		$this->assertFalse(strpos($outputData, "<li>"));
+		$this->assertFalse(strpos($outputData, "<strong>"));
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,3 @@
 <?php
-
 declare(strict_types=1);
-
-require_once(__DIR__.'/../vendor/autoload.php');
+require_once(dirname(__DIR__) . '/src/loader.php');


### PR DESCRIPTION
This adds a new custom `HtmlSanitizer` extension that handles input shortcoding (for images, mentions, and read-mores), and rewrites most of the `WFText` class. 

Most individual commits in this PR have explanations for the decisions I've made in that commit, because this isn't exactly a small change 😅 